### PR TITLE
LongerChain5 proposition no longer refs LengthChain props

### DIFF
--- a/src/Chains.hs
+++ b/src/Chains.hs
@@ -130,9 +130,9 @@ propLongerChain4 = longerChain chain3 chain4 == chain3
 
 propLongerChain5 :: Bool
 propLongerChain5 = and [ propLongerChain1
-                       , propLengthChain2
-                       , propLengthChain3
-                       , propLengthChain4
+                       , propLongerChain2
+                       , propLongerChain3
+                       , propLongerChain4
                        ]
 
 -- Task Chains-5.


### PR DESCRIPTION
Unless this is an intentional test for the homework exercise, propLongerChain5 (which, I assume should be for testing all LongerChain propositions) should reference propLongerChain2, 3 and 4, not propLengthChain2, 3 and 4.